### PR TITLE
Fixing small typo in `set.md`

### DIFF
--- a/content/docs/steps/set.md
+++ b/content/docs/steps/set.md
@@ -105,7 +105,6 @@ This example will result in these context variables:
 var1: 'one'
 var2: 'one two'
 var3: 'one two three'
-}
 ```
 
 ## examples


### PR DESCRIPTION
I believe there is an extraneous `}` in one of the examples